### PR TITLE
Add a rule to ignore "Channels new to you" from search results

### DIFF
--- a/Search.txt
+++ b/Search.txt
@@ -9,6 +9,7 @@ www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/Previously wa
 www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/Related to your search/i))
 www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/Related Movies/i))
 www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/New for you/i))
+www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/Channels new to you/i))
 www.youtube.com##ytd-shelf-renderer.ytd-item-section-renderer.style-scope:nth-of-type(1):has(span:has-text(/Latest from/i))
 www.youtube.com##ytd-horizontal-card-list-renderer.ytd-item-section-renderer.style-scope:has-text(/People also search for/i)
 www.youtube.com##ytd-horizontal-card-list-renderer.ytd-item-section-renderer.style-scope:has-text(/Searches related to/i)

--- a/YouTubeFilterList.txt
+++ b/YouTubeFilterList.txt
@@ -10,6 +10,7 @@ www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/Previously wa
 www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/Related to your search/i))
 www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/Related Movies/i))
 www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/New for you/i))
+www.youtube.com##ytd-shelf-renderer.style-scope:has(span:has-text(/Channels new to you/i))
 www.youtube.com##ytd-shelf-renderer.ytd-item-section-renderer.style-scope:nth-of-type(1):has(span:has-text(/Latest from/i))
 www.youtube.com##ytd-horizontal-card-list-renderer.ytd-item-section-renderer.style-scope:has-text(/People also search for/i)
 www.youtube.com##ytd-horizontal-card-list-renderer.ytd-item-section-renderer.style-scope:has-text(/Searches related to/i)


### PR DESCRIPTION
I found `Channels new to you` still appears on search results. This PR fixes it.
![Screenshot-Channels_new_to_you](https://user-images.githubusercontent.com/29563481/184495845-09c71915-c127-452b-92fd-9187e3988ab4.jpg)
