### PR TITLE
Decrease height of #frosted-glass top bar

### DIFF
--- a/Home.txt
+++ b/Home.txt
@@ -19,5 +19,6 @@ youtube.com##ytd-rich-grid-row,#contents.ytd-rich-grid-row:style(display: conten
 ! Keyword Bar (removes "sort by" on video page)
 www.youtube.com###scroll-container > .ytd-feed-filter-chip-bar-renderer.style-scope
 www.youtube.com###header > .ytd-rich-grid-renderer.style-scope
+www.youtube.com###frosted-glass:style(height: 55px !important;)
 ! Voice Search Button
 www.youtube.com###voice-search-button


### PR DESCRIPTION
This element covers up part of the first row of videos in the homepage. I reduced its height to 55px.
Check the screenshots without and with this rule:

![image](https://github.com/user-attachments/assets/4fe6e5eb-d1d2-454b-a7b3-5772cd53c108)
![image](https://github.com/user-attachments/assets/fcfe9759-0676-4892-9878-2c0b09825cfe)
